### PR TITLE
Fixed Visual Display of Tax Percentages from 0.1% to 10%

### DIFF
--- a/app/src/main/java/ServerLogic/actions/RequestPayTax.java
+++ b/app/src/main/java/ServerLogic/actions/RequestPayTax.java
@@ -43,7 +43,7 @@ public class RequestPayTax implements ServerActionInterface {
                     playerCashNew = playerCashOld - Config.MAX_TAX_AMOUNT;
                 }
 
-                server.broadcast(Constants.GAMEVIEW_ACTIVITY_TYPE, Constants.PREFIX_ACTIVITY_BROADCAST, new String[]{"pay_tax_activity_text", playerName, String.valueOf(Config.TAX_PERCENTAGE * 100), String.valueOf(playerCashOld), String.valueOf(playerCashNew)});
+                server.broadcast(Constants.GAMEVIEW_ACTIVITY_TYPE, Constants.PREFIX_ACTIVITY_BROADCAST, new String[]{"pay_tax_activity_text", playerName, String.valueOf((int) (Config.TAX_PERCENTAGE * 100)), String.valueOf(playerCashOld), String.valueOf(playerCashNew)});
             } else if (mapField.getName().equals("Steuerabgabe")) { // Reduce playercash with static tax amount
                 playerCashNew = playerCashOld - Config.STATIC_TAX_AMOUNT;
 


### PR DESCRIPTION
Multiplied the tax-percentage by 100, so that the text shows 10% instead of 0.1%. Removed the decimal character by converting the percentages that are to be display to an Integer.